### PR TITLE
Rename Sites to Syndication Endpoints

### DIFF
--- a/includes/admin/class-settings-screen.php
+++ b/includes/admin/class-settings-screen.php
@@ -3,10 +3,19 @@
  * Settings Screen
  *
  * Responsible for plugin-level settings screens.
+ *
+ * @since 2.1
+ * @package Automattic\Syndication\Admin
  */
 
 namespace Automattic\Syndication\Admin;
 
+/**
+ * Class Settings_Screen
+ *
+ * @since 2.1
+ * @package Automattic\Syndication\Admin
+ */
 class Settings_Screen {
 	/**
 	 * Settings_Screen constructor.
@@ -49,7 +58,6 @@ class Settings_Screen {
 	}
 
 	public function register_syndicate_settings() {
-
 		add_submenu_page(
 			'options-general.php',
 			esc_html__( 'Syndication Settings', 'push-syndication' ),
@@ -61,6 +69,14 @@ class Settings_Screen {
 		);
 	}
 
+	/**
+	 * Display Syndicate Settings
+	 *
+	 * Registers the setting sections and fields and outputs the markup for the
+	 * settings page.
+	 *
+	 * @return void
+	 */
 	public function display_syndicate_settings() {
 		// @todo all validation and sanitization should be moved to a separate object.
 		add_settings_section( 'push_syndicate_pull_sitegroups', esc_html__( 'Syndication Endpoint Groups' , 'push-syndication' ), array( $this, 'display_pull_sitegroups_description' ), 'push_syndicate_pull_sitegroups' );
@@ -80,6 +96,7 @@ class Settings_Screen {
 			array( $this, 'display_delete_pushed_posts_description' ),
 			'delete_pushed_posts'
 		);
+
 		add_settings_field(
 			'delete_post_check',
 			esc_html__( 'Delete pushed posts', 'push-syndication' ),
@@ -87,17 +104,13 @@ class Settings_Screen {
 			'delete_pushed_posts',
 			'delete_pushed_posts'
 		);
-
 		?>
-
 		<div class="wrap" xmlns="http://www.w3.org/1999/html">
-
 			<?php screen_icon(); // @todo custom screen icon ?>
 
 			<h2><?php esc_html_e( 'Syndication Settings', 'push-syndication' ); ?></h2>
 
 			<form action="options.php" method="post">
-
 				<?php settings_fields( 'push_syndicate_settings' ); ?>
 
 				<?php do_settings_sections( 'push_syndicate_pull_sitegroups' ); ?>
@@ -111,22 +124,33 @@ class Settings_Screen {
 				<?php do_settings_sections( 'delete_pushed_posts' ); ?>
 
 				<?php submit_button(); ?>
-
 			</form>
-
 		</div>
-
 	<?php
-
 	}
 
+	/**
+	 * Display Pull Sitegroups Description
+	 *
+	 * Displays a description under the group selection heading on the settings page.
+	 *
+	 * @return void
+	 */
 	public function display_pull_sitegroups_description() {
 		echo esc_html__( 'Select the Syndication Endpoint Groups to pull content', 'push-syndication' );
 	}
 
+	/**
+	 * Display Pull Sitegroups Selection
+	 *
+	 * Displays a checkbox form item to select Syndication Endpoint Groups to enable.
+	 *
+	 * @return void
+	 */
 	public function display_pull_sitegroups_selection() {
 		global $settings_manager;
-		// get all sitegroups
+
+		// Get all sitegroups.
 		$sitegroups = get_terms(
 			'syn_sitegroup',
 			array(
@@ -144,21 +168,16 @@ class Settings_Screen {
 		}
 
 		foreach ( $sitegroups as $sitegroup ) {
-
-			?>
-
-			<p>
-				<label>
-					<input type="checkbox" name="push_syndicate_settings[selected_pull_sitegroups][]" value="<?php echo esc_html( $sitegroup->slug ); ?>" <?php $this->checked_array( $sitegroup->slug, $settings_manager->get_setting( 'selected_pull_sitegroups' ) ) ?> />
-					<?php echo esc_html( $sitegroup->name ); ?>
-				</label>
-				<?php echo esc_html( $sitegroup->description ); ?>
-			</p>
-
+		?>
+		<p>
+			<label>
+				<input type="checkbox" name="push_syndicate_settings[selected_pull_sitegroups][]" value="<?php echo esc_html( $sitegroup->slug ); ?>" <?php $this->checked_array( $sitegroup->slug, $settings_manager->get_setting( 'selected_pull_sitegroups' ) ) ?> />
+				<?php echo esc_html( $sitegroup->name ); ?>
+			</label>
+			<?php echo esc_html( $sitegroup->description ); ?>
+		</p>
 		<?php
-
 		}
-
 	}
 
 	public  function display_pull_options_description() {
@@ -171,14 +190,18 @@ class Settings_Screen {
 	}
 
 	/**
+	 * Display Max Pull Attempts
+	 *
 	 * Display the form field for the push_syndication_max_pull_attempts option.
+	 *
+	 * @return void
 	 */
 	public function display_max_pull_attempts() {
 		global $settings_manager;
 		?>
 		<input type="text" size="10" name="push_syndicate_settings[push_syndication_max_pull_attempts]" value="<?php echo esc_attr( $settings_manager->get_setting( 'push_syndication_max_pull_attempts', 0 ) ); ?>" />
 		<p><?php echo esc_html__( 'Syndication Endpoint will be disabled after failure threshold is reached. Set to 0 to disable.', 'push-syndication' ); ?></p>
-	<?php
+		<?php
 	}
 
 	/**
@@ -261,6 +284,16 @@ class Settings_Screen {
 		echo '<input type="text" size=100 name="push_syndicate_settings[client_secret]" value="' . esc_attr( $settings_manager->get_setting( 'client_secret' ) ) . '"/>';
 	}
 
+	/**
+	 * Checked Array
+	 *
+	 * Checks is a value exists in an array, and if it does outputs markup to
+	 * mark a checkbox as checked. Used for checkbox inputs on forms.
+	 *
+	 * @param string $value The needle.
+	 * @param array  $group The haystack.
+	 * @return void
+	 */
 	public function checked_array( $value, $group ) {
 		if ( ! empty( $group ) ) {
 			if ( in_array( $value, $group, true ) ) {

--- a/includes/admin/class-settings-screen.php
+++ b/includes/admin/class-settings-screen.php
@@ -8,16 +8,15 @@
 namespace Automattic\Syndication\Admin;
 
 class Settings_Screen {
-
-
+	/**
+	 * Settings_Screen constructor.
+	 */
 	public function __construct() {
-
 		add_action( 'admin_init', array( $this, 'admin_init' ) );
 		add_action( 'admin_menu', array( $this, 'register_syndicate_settings' ) );
 	}
 
 	public function admin_init() {
-
 		register_setting( 'push_syndicate_settings', 'push_syndicate_settings', array( $this, 'push_syndicate_settings_validate' ) );
 		register_setting( 'push_syndicate_settings', 'push_syndication_max_pull_attempts', array( $this, 'validate_max_pull_attempts' ) );
 	}
@@ -63,28 +62,27 @@ class Settings_Screen {
 	}
 
 	public function display_syndicate_settings() {
-
 		// @todo all validation and sanitization should be moved to a separate object.
-		add_settings_section( 'push_syndicate_pull_sitegroups', esc_html__( 'Site Groups' , 'push-syndication' ), array( $this, 'display_pull_sitegroups_description' ), 'push_syndicate_pull_sitegroups' );
-		add_settings_field( 'pull_sitegroups_selection', esc_html__( 'select sitegroups', 'push-syndication' ), array( $this, 'display_pull_sitegroups_selection' ), 'push_syndicate_pull_sitegroups', 'push_syndicate_pull_sitegroups' );
+		add_settings_section( 'push_syndicate_pull_sitegroups', esc_html__( 'Syndication Endpoint Groups' , 'push-syndication' ), array( $this, 'display_pull_sitegroups_description' ), 'push_syndicate_pull_sitegroups' );
+		add_settings_field( 'pull_sitegroups_selection', esc_html__( 'Select Syndication Endpoint Groups', 'push-syndication' ), array( $this, 'display_pull_sitegroups_selection' ), 'push_syndicate_pull_sitegroups', 'push_syndicate_pull_sitegroups' );
 
 		add_settings_section( 'push_syndicate_pull_options', esc_html__( 'Pull Options' , 'push-syndication' ), array( $this, 'display_pull_options_description' ), 'push_syndicate_pull_options' );
 		add_settings_field( 'pull_time_interval', esc_html__( 'Specify time interval in seconds', 'push-syndication' ), array( $this, 'display_time_interval_selection' ), 'push_syndicate_pull_options', 'push_syndicate_pull_options' );
 		add_settings_field( 'max_pull_attempts', esc_html__( 'Maximum pull attempts', 'push-syndication' ), array( $this, 'display_max_pull_attempts' ), 'push_syndicate_pull_options', 'push_syndicate_pull_options' );
-		add_settings_field( 'update_pulled_posts', esc_html__( 'update pulled posts', 'push-syndication' ), array( $this, 'display_update_pulled_posts_selection' ), 'push_syndicate_pull_options', 'push_syndicate_pull_options' );
+		add_settings_field( 'update_pulled_posts', esc_html__( 'Update pulled posts', 'push-syndication' ), array( $this, 'display_update_pulled_posts_selection' ), 'push_syndicate_pull_options', 'push_syndicate_pull_options' );
 
 		add_settings_section( 'push_syndicate_post_types', esc_html__( 'Post Types' , 'push-syndication' ), array( $this, 'display_push_post_types_description' ), 'push_syndicate_post_types' );
-		add_settings_field( 'post_type_selection', esc_html__( 'select post types', 'push-syndication' ), array( $this, 'display_post_types_selection' ), 'push_syndicate_post_types', 'push_syndicate_post_types' );
+		add_settings_field( 'post_type_selection', esc_html__( 'Select post types', 'push-syndication' ), array( $this, 'display_post_types_selection' ), 'push_syndicate_post_types', 'push_syndicate_post_types' );
 
 		add_settings_section(
 			'delete_pushed_posts',
-			esc_html__( ' Delete Pushed Posts ', 'push-syndication' ),
+			esc_html__( 'Delete Pushed Posts', 'push-syndication' ),
 			array( $this, 'display_delete_pushed_posts_description' ),
 			'delete_pushed_posts'
 		);
 		add_settings_field(
 			'delete_post_check',
-			esc_html__( ' delete pushed posts ', 'push-syndication' ),
+			esc_html__( 'Delete pushed posts', 'push-syndication' ),
 			array( $this, 'display_delete_pushed_posts_selection' ),
 			'delete_pushed_posts',
 			'delete_pushed_posts'
@@ -94,7 +92,7 @@ class Settings_Screen {
 
 		<div class="wrap" xmlns="http://www.w3.org/1999/html">
 
-			<?php screen_icon(); // @TODO custom screen icon ?>
+			<?php screen_icon(); // @todo custom screen icon ?>
 
 			<h2><?php esc_html_e( 'Syndication Settings', 'push-syndication' ); ?></h2>
 
@@ -123,7 +121,7 @@ class Settings_Screen {
 	}
 
 	public function display_pull_sitegroups_description() {
-		echo esc_html__( 'Select the sitegroups to pull content', 'push-syndication' );
+		echo esc_html__( 'Select the Syndication Endpoint Groups to pull content', 'push-syndication' );
 	}
 
 	public function display_pull_sitegroups_selection() {
@@ -138,9 +136,9 @@ class Settings_Screen {
 			)
 		);
 
-		// if there are no sitegroups defined return
+		// If there are no Syndication Endpoint Groups defined return.
 		if ( empty( $sitegroups ) ) {
-			echo '<p>' . esc_html__( 'No sitegroups defined yet. You must group your sites into sitegroups to syndicate content', 'push-syndication' ) . '</p>';
+			echo '<p>' . esc_html__( 'No Syndication Endpoint Groups defined yet. You must group your Syndication Endpoints into Syndication Endpoint Groups to syndicate content', 'push-syndication' ) . '</p>';
 			echo '<p><a href="' . esc_url( get_admin_url() . 'edit-tags.php?taxonomy=syn_sitegroup&post_type=syn_site' ) . '" target="_blank" >' . esc_html__( 'Create new', 'push-syndication' ) . '</a></p>';
 			return;
 		}
@@ -179,7 +177,7 @@ class Settings_Screen {
 		global $settings_manager;
 		?>
 		<input type="text" size="10" name="push_syndicate_settings[push_syndication_max_pull_attempts]" value="<?php echo esc_attr( $settings_manager->get_setting( 'push_syndication_max_pull_attempts', 0 ) ); ?>" />
-		<p><?php echo esc_html__( 'Site will be disabled after failure threshold is reached. Set to 0 to disable.', 'push-syndication' ); ?></p>
+		<p><?php echo esc_html__( 'Syndication Endpoint will be disabled after failure threshold is reached. Set to 0 to disable.', 'push-syndication' ); ?></p>
 	<?php
 	}
 
@@ -263,51 +261,9 @@ class Settings_Screen {
 		echo '<input type="text" size=100 name="push_syndicate_settings[client_secret]" value="' . esc_attr( $settings_manager->get_setting( 'client_secret' ) ) . '"/>';
 	}
 
-	public function display_sitegroups_selection() {
-
-		echo '<h3>' . esc_html__( 'Select Sitegroups', 'push-syndication' ) . '</h3>';
-
-		$selected_sitegroups = get_option( 'syn_selected_sitegroups' );
-		$selected_sitegroups = ! empty( $selected_sitegroups ) ? $selected_sitegroups : array() ;
-
-		// get all sitegroups
-		$sitegroups = get_terms(
-			'syn_sitegroup',
-			array(
-				'fields'        => 'all',
-				'hide_empty'    => false,
-				'orderby'       => 'name',
-			)
-		);
-
-		// if there are no sitegroups defined return
-		if ( empty( $sitegroups ) ) {
-			echo '<p>' . esc_html__( 'No sitegroups defined yet. You must group your sites into sitegroups to syndicate content', 'push-syndication' ) . '</p>';
-			echo '<p><a href="' . esc_url( get_admin_url() . 'edit-tags.php?taxonomy=syn_sitegroup&post_type=syn_site' ) . '" target="_blank" >' . esc_html__( 'Create new', 'push-syndication' ) . '</a></p>';
-			return;
-		}
-
-		foreach ( $sitegroups as $sitegroup ) {
-
-			?>
-
-			<p>
-				<label>
-					<input type="checkbox" name="syn_selected_sitegroups[]" value="<?php echo esc_html( $sitegroup->slug ); ?>" <?php $this->checked_array( $sitegroup->slug, $selected_sitegroups ) ?> />
-					<?php echo esc_html( $sitegroup->name ); ?>
-				</label>
-				<?php echo esc_html( $sitegroup->description ); ?>
-			</p>
-
-		<?php
-
-		}
-
-	}
-
 	public function checked_array( $value, $group ) {
 		if ( ! empty( $group ) ) {
-			if ( in_array( $value, $group ) ) {
+			if ( in_array( $value, $group, true ) ) {
 				echo 'checked="checked"';
 			}
 		}

--- a/includes/admin/class-settings-screen.php
+++ b/includes/admin/class-settings-screen.php
@@ -74,8 +74,6 @@ class Settings_Screen {
 	 *
 	 * Registers the setting sections and fields and outputs the markup for the
 	 * settings page.
-	 *
-	 * @return void
 	 */
 	public function display_syndicate_settings() {
 		// @todo all validation and sanitization should be moved to a separate object.
@@ -133,8 +131,6 @@ class Settings_Screen {
 	 * Display Pull Sitegroups Description
 	 *
 	 * Displays a description under the group selection heading on the settings page.
-	 *
-	 * @return void
 	 */
 	public function display_pull_sitegroups_description() {
 		echo esc_html__( 'Select the Syndication Endpoint Groups to pull content', 'push-syndication' );
@@ -144,8 +140,6 @@ class Settings_Screen {
 	 * Display Pull Sitegroups Selection
 	 *
 	 * Displays a checkbox form item to select Syndication Endpoint Groups to enable.
-	 *
-	 * @return void
 	 */
 	public function display_pull_sitegroups_selection() {
 		global $settings_manager;
@@ -193,8 +187,6 @@ class Settings_Screen {
 	 * Display Max Pull Attempts
 	 *
 	 * Display the form field for the push_syndication_max_pull_attempts option.
-	 *
-	 * @return void
 	 */
 	public function display_max_pull_attempts() {
 		global $settings_manager;
@@ -287,12 +279,11 @@ class Settings_Screen {
 	/**
 	 * Checked Array
 	 *
-	 * Checks is a value exists in an array, and if it does outputs markup to
+	 * Checks if a value exists in an array, and if it does outputs markup to
 	 * mark a checkbox as checked. Used for checkbox inputs on forms.
 	 *
 	 * @param string $value The needle.
 	 * @param array  $group The haystack.
-	 * @return void
 	 */
 	public function checked_array( $value, $group ) {
 		if ( ! empty( $group ) ) {

--- a/includes/admin/class-site-edit-screen.php
+++ b/includes/admin/class-site-edit-screen.php
@@ -24,7 +24,7 @@ class Site_Edit_Screen {
 
 		global $typenow;
 
-		if ( 'syn_site' == $typenow ) {
+		if ( 'syn_site' === $typenow ) {
 			if ( 'post.php' === $hook || 'post-new.php' === $hook ) {
 				wp_enqueue_style( 'syn-edit-sites', SYNDICATION_URL . 'assets/css/admin-sites-list.css', array(), SYNDICATION_VERSION );
 				//@todo verify below working, maybe need `wp_deregister_script` here
@@ -35,9 +35,9 @@ class Site_Edit_Screen {
 
 	public function site_metaboxes() {
 
-		add_meta_box( 'sitediv', __( ' Site Settings ' ), array( $this, 'add_site_settings_metabox' ), 'syn_site', 'normal', 'high' );
+		add_meta_box( 'sitediv', __( ' Syndication Endpoint Settings ' ), array( $this, 'add_site_settings_metabox' ), 'syn_site', 'normal', 'high' );
 		remove_meta_box( 'submitdiv', 'syn_site', 'side' );
-		add_meta_box( 'submitdiv', __( ' Site Status ' ), array( $this, 'add_site_status_metabox' ), 'syn_site', 'side', 'high' );
+		add_meta_box( 'submitdiv', __( ' Syndication Endpoint Status ' ), array( $this, 'add_site_status_metabox' ), 'syn_site', 'side', 'high' );
 	}
 
 	public function add_site_status_metabox( $site ) {
@@ -90,8 +90,8 @@ class Site_Edit_Screen {
 					<img src="<?php echo esc_url( admin_url( 'images/wpspin_light.gif' ) ); ?>" class="ajax-loading" id="ajax-loading" alt="" />
 					<?php
 					if ( !in_array( $site_enabled, array( 'on', 'off' ) ) || 0 == $site->ID ) { ?>
-						<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr_e('Add Site') ?>" />
-						<?php submit_button( __( 'Add Site', 'push-syndication' ), 'primary', 'enabled', false, array( 'tabindex' => '5', 'accesskey' => 'p' ) ); ?>
+						<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr_e('Add Syndication Endpoint') ?>" />
+						<?php submit_button( __( 'Add Syndication Endpoint', 'push-syndication' ), 'primary', 'enabled', false, array( 'tabindex' => '5', 'accesskey' => 'p' ) ); ?>
 					<?php } else { ?>
 						<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr_e('Update') ?>" />
 						<input name="save" type="submit" class="button-primary" id="publish" tabindex="5" accesskey="p" value="<?php esc_attr_e( 'Update', 'push-syndication' ) ?>" />
@@ -123,14 +123,14 @@ class Site_Edit_Screen {
 		if ( $transport_type ) {
 
 			/**
-			 * Fires when rendering the Syndication site settings metabox.
+			 * Fires when rendering the Syndication settings metabox.
 			 *
 			 * @param string     $transport_type The client transport type.
-			 * @param int        $post_id        The post_id of the site being rendered.
+			 * @param int        $post_id        The post_id of the Syndication Endpoint being rendered.
 			 */
 			do_action( 'syndication/render_site_options/' . $transport_type, $post->ID );
 		} else {
-			echo '<p>' . __( 'No client configured for this site.' ) . '</p>';
+			echo '<p>' . __( 'No client configured for this Syndication Endpoint.' ) . '</p>';
 		}
 
 		?>

--- a/includes/admin/class-site-edit-screen.php
+++ b/includes/admin/class-site-edit-screen.php
@@ -43,7 +43,6 @@ class Site_Edit_Screen {
 	 * @since 2.1
 	 * @see admin_enqueue_scripts
 	 * @param string $hook Current admin page.
-	 * @return void
 	 */
 	public function load_scripts_and_styles( $hook ) {
 		global $typenow;
@@ -61,8 +60,6 @@ class Site_Edit_Screen {
 	 * Site Metaboxes
 	 *
 	 * Adds and removes metaboxes from the Syndication Endpoint edit screen.
-	 *
-	 * @return void
 	 */
 	public function site_metaboxes() {
 		add_meta_box( 'sitediv', __( ' Syndication Endpoint Settings ' ), array( $this, 'add_site_settings_metabox' ), 'syn_site', 'normal', 'high' );
@@ -78,7 +75,6 @@ class Site_Edit_Screen {
 	 *
 	 * @see site_metaboxes()
 	 * @param \WP_Post $site Object of the current Syndication Endpoint being viewed.
-	 * @return void
 	 */
 	public function add_site_status_metabox( $site ) {
 		$site_enabled = get_post_meta( $site->ID, 'syn_site_enabled', true );
@@ -123,7 +119,7 @@ class Site_Edit_Screen {
 			<div id="major-publishing-actions">
 
 				<div id="delete-action">
-					<a class="submitdelete deletion" href="<?php echo get_delete_post_link( $site->ID ); ?>"><?php esc_html_e( 'Move to Trash', 'push-syndication' ); ?></a>
+					<a class="submitdelete deletion" href="<?php echo esc_url( get_delete_post_link( $site->ID ) ); ?>"><?php esc_html_e( 'Move to Trash', 'push-syndication' ); ?></a>
 				</div>
 
 				<div id="publishing-action">
@@ -152,7 +148,6 @@ class Site_Edit_Screen {
 	 *
 	 * @see site_metaboxes()
 	 * @param \WP_Post $post Post object of the current post being viewed.
-	 * @return void
 	 */
 	public function add_site_settings_metabox( $post ) {
 		global $post;

--- a/includes/admin/class-site-edit-screen.php
+++ b/includes/admin/class-site-edit-screen.php
@@ -1,18 +1,33 @@
 <?php
 /**
  * Site Edit Screen
+ *
+ * The functionality on the add/edit screen of a Syndication Endpoint.
+ *
+ * @since 2.1
+ * @package Automattic\Syndication\Admin
  */
 
 namespace Automattic\Syndication\Admin;
 
 use Automattic\Syndication\Client_Manager;
 
+/**
+ * Class Site_Edit_Screen
+ *
+ * @since 2.1
+ * @package Automattic\Syndication\Admin
+ */
 class Site_Edit_Screen {
 
 	protected $_client_manager;
 
+	/**
+	 * Site_Edit_Screen constructor.
+	 *
+	 * @param Client_Manager $client_manager Client manager object.
+	 */
 	public function __construct( Client_Manager $client_manager ) {
-
 		$this->_client_manager = $client_manager;
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_scripts_and_styles' ) );
@@ -20,8 +35,17 @@ class Site_Edit_Screen {
 		add_action( 'save_post', array( $this, 'save_site_settings' ) );
 	}
 
+	/**
+	 * Load Scripts and Styles
+	 *
+	 * Enqueues CSS and JS to the Syndication Endpoint edit screen.
+	 *
+	 * @since 2.1
+	 * @see admin_enqueue_scripts
+	 * @param string $hook Current admin page.
+	 * @return void
+	 */
 	public function load_scripts_and_styles( $hook ) {
-
 		global $typenow;
 
 		if ( 'syn_site' === $typenow ) {
@@ -33,13 +57,29 @@ class Site_Edit_Screen {
 		}
 	}
 
+	/**
+	 * Site Metaboxes
+	 *
+	 * Adds and removes metaboxes from the Syndication Endpoint edit screen.
+	 *
+	 * @return void
+	 */
 	public function site_metaboxes() {
-
 		add_meta_box( 'sitediv', __( ' Syndication Endpoint Settings ' ), array( $this, 'add_site_settings_metabox' ), 'syn_site', 'normal', 'high' );
 		remove_meta_box( 'submitdiv', 'syn_site', 'side' );
 		add_meta_box( 'submitdiv', __( ' Syndication Endpoint Status ' ), array( $this, 'add_site_status_metabox' ), 'syn_site', 'side', 'high' );
 	}
 
+	/**
+	 * Add Site Status Metabox
+	 *
+	 * Adds a metabox which displays the status of the Syndication Endpoint. Also
+	 * provides quick links to additional functionality.
+	 *
+	 * @see site_metaboxes()
+	 * @param \WP_Post $site Object of the current Syndication Endpoint being viewed.
+	 * @return void
+	 */
 	public function add_site_status_metabox( $site ) {
 		$site_enabled = get_post_meta( $site->ID, 'syn_site_enabled', true );
 		?>
@@ -47,35 +87,35 @@ class Site_Edit_Screen {
 			<div id="minor-publishing">
 				<div id="misc-publishing-actions">
 					<div class="misc-pub-section">
-						<label for="post_status"><?php _e( 'Status:', 'push-syndication' ) ?></label>
+						<label for="post_status"><?php esc_html_e( 'Status:', 'push-syndication' ) ?></label>
 						<span id="post-status-display">
 						<?php
 						switch ( $site_enabled ) {
 							case 'on':
-								_e( 'Enabled', 'push-syndication' );
+								esc_html_e( 'Enabled', 'push-syndication' );
 								break;
 							case 'off':
 							default:
-								_e( 'Disabled', 'push-syndication' );
+								esc_html_e( 'Disabled', 'push-syndication' );
 								break;
 						}
 						?>
 						</span>
 
-						<a href="#post_status" class="edit-post-status hide-if-no-js" tabindex='4'><?php _e( 'Edit', 'push-syndication' ) ?></a>
+						<a href="#post_status" class="edit-post-status hide-if-no-js" tabindex='4'><?php esc_html_e( 'Edit', 'push-syndication' ) ?></a>
 
 						<div id="post-status-select" class="hide-if-js">
 							<input type="hidden" name="post_status" value="publish" />
 							<select name='site_enabled' id='post_status' tabindex='4'>
-								<option<?php selected( $site_enabled, 'on' ); ?> value='on'><?php _e('Enabled', 'push-syndication' ) ?></option>
-								<option<?php selected( $site_enabled, 'off' ); ?> value='off'><?php _e('Disabled', 'push-syndication' ) ?></option>
+								<option<?php selected( $site_enabled, 'on' ); ?> value='on'><?php esc_html_e( 'Enabled', 'push-syndication' ) ?></option>
+								<option<?php selected( $site_enabled, 'off' ); ?> value='off'><?php esc_html_e( 'Disabled', 'push-syndication' ) ?></option>
 							</select>
-							<a href="#post_status" class="save-post-status hide-if-no-js button"><?php _e( 'OK', 'push-syndication' ); ?></a>
+							<a href="#post_status" class="save-post-status hide-if-no-js button"><?php esc_html_e( 'OK', 'push-syndication' ); ?></a>
 						</div>
 
 					</div>
 
-					<div id="timestampdiv" class="hide-if-js"><?php touch_time(0, 1, 4); ?></div>
+					<div id="timestampdiv" class="hide-if-js"><?php touch_time( 0, 1, 4 ); ?></div>
 				</div>
 				<div class="clear"></div>
 			</div>
@@ -83,17 +123,17 @@ class Site_Edit_Screen {
 			<div id="major-publishing-actions">
 
 				<div id="delete-action">
-					<a class="submitdelete deletion" href="<?php echo get_delete_post_link($site->ID); ?>"><?php echo __( 'Move to Trash', 'push-syndication' ); ?></a>
+					<a class="submitdelete deletion" href="<?php echo get_delete_post_link( $site->ID ); ?>"><?php esc_html_e( 'Move to Trash', 'push-syndication' ); ?></a>
 				</div>
 
 				<div id="publishing-action">
 					<img src="<?php echo esc_url( admin_url( 'images/wpspin_light.gif' ) ); ?>" class="ajax-loading" id="ajax-loading" alt="" />
 					<?php
-					if ( !in_array( $site_enabled, array( 'on', 'off' ) ) || 0 == $site->ID ) { ?>
-						<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr_e('Add Syndication Endpoint') ?>" />
+					if ( ! in_array( $site_enabled, array( 'on', 'off' ), true ) || 0 === $site->ID ) { ?>
+						<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr_e( 'Add Syndication Endpoint', 'push-syndication' ) ?>" />
 						<?php submit_button( __( 'Add Syndication Endpoint', 'push-syndication' ), 'primary', 'enabled', false, array( 'tabindex' => '5', 'accesskey' => 'p' ) ); ?>
 					<?php } else { ?>
-						<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr_e('Update') ?>" />
+						<input name="original_publish" type="hidden" id="original_publish" value="<?php esc_attr_e( 'Update', 'push-syndication' ) ?>" />
 						<input name="save" type="submit" class="button-primary" id="publish" tabindex="5" accesskey="p" value="<?php esc_attr_e( 'Update', 'push-syndication' ) ?>" />
 					<?php } ?>
 				</div>
@@ -105,23 +145,30 @@ class Site_Edit_Screen {
 	<?php
 	}
 
+	/**
+	 * Add Site Settings Metabox
+	 *
+	 * Adds a settings metabox to the Syndication Endpoint edit screen.
+	 *
+	 * @see site_metaboxes()
+	 * @param \WP_Post $post Post object of the current post being viewed.
+	 * @return void
+	 */
 	public function add_site_settings_metabox( $post ) {
-
 		global $post;
 
 		$transport_type = get_post_meta( $post->ID, 'syn_transport_type', true );
 		$site_enabled   = get_post_meta( $post->ID, 'syn_site_enabled', true );
 
-		// default values
+		// Default values.
 		$site_enabled   = ! empty( $site_enabled ) ? $site_enabled : 'off';
 
-		// nonce for verification when saving
+		// Nonce for verification when saving.
 		wp_nonce_field( plugin_basename( __FILE__ ), 'site_settings_noncename' );
 
 		$this->display_transports( $transport_type );
 
 		if ( $transport_type ) {
-
 			/**
 			 * Fires when rendering the Syndication settings metabox.
 			 *
@@ -130,15 +177,11 @@ class Site_Edit_Screen {
 			 */
 			do_action( 'syndication/render_site_options/' . $transport_type, $post->ID );
 		} else {
-			echo '<p>' . __( 'No client configured for this Syndication Endpoint.' ) . '</p>';
+			echo '<p>' . esc_html__( 'No client configured for this Syndication Endpoint.', 'push-syndication' ) . '</p>';
 		}
-
 		?>
-
 		<div class="clear"></div>
-
-	<?php
-
+		<?php
 	}
 
 	public function display_transports( $transport_type ) {

--- a/includes/admin/class-site-list-screen.php
+++ b/includes/admin/class-site-list-screen.php
@@ -1,23 +1,44 @@
 <?php
 /**
  * Site List Screen
+ *
+ * Functionality added to the list of Syndication Endpoints screen.
+ *
+ * @since 2.1
+ * @package Automattic\Syndication\Admin
  */
 
 namespace Automattic\Syndication\Admin;
 
+/**
+ * Class Site_List_Screen
+ *
+ * @since 2.1
+ * @package Automattic\Syndication\Admin
+ */
 class Site_List_Screen {
-
+	/**
+	 * Site_List_Screen constructor.
+	 */
 	public function __construct() {
-
-		// loading necessary styles and scripts
+		// Loading necessary styles and scripts.
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_scripts_and_styles' ) );
 
-		// custom columns
+		// Custom columns.
 		add_filter( 'manage_edit-syn_site_columns', array( $this, 'add_new_columns' ) );
 		add_action( 'manage_syn_site_posts_custom_column', array( $this, 'manage_columns' ), 10, 2 );
 	}
 
-
+	/**
+	 * Load Scripts and Styles
+	 *
+	 * Enqueues CSS and JS to the Syndication Endpoint listing screen.
+	 *
+	 * @since 2.1
+	 * @see admin_enqueue_scripts
+	 * @param string $hook Current admin page.
+	 * @return void
+	 */
 	public function load_scripts_and_styles( $hook ) {
 		global $typenow;
 
@@ -28,6 +49,14 @@ class Site_List_Screen {
 		}
 	}
 
+	/**
+	 * Add New Columns
+	 *
+	 * Add new columns to the Syndication Endpoint listing screen.
+	 *
+	 * @param array $columns The existing columns.
+	 * @return array
+	 */
 	public function add_new_columns( $columns ) {
 		$new_columns                  = array();
 		$new_columns['cb']            = '<input type="checkbox" />';
@@ -39,20 +68,18 @@ class Site_List_Screen {
 	}
 
 	public function manage_columns( $column_name, $id ) {
-
 		global $client_manager;
+
 		switch ( $column_name ) {
-
-			// Output the client label
+			// Output the client label.
 			case 'client-type':
-
-				// Fetch the site transport type
+				// Fetch the site transport type.
 				$transport_type = get_post_meta( $id, 'syn_transport_type', true );
 
-				// Fetch the corresponding client
+				// Fetch the corresponding client.
 				$pull_client = $client_manager->get_pull_or_push_client( $transport_type );
 
-				// Output the client name
+				// Output the client name.
 				if ( isset( $pull_client['label'] ) ) {
 					echo esc_html( $pull_client['label'] );
 				}

--- a/includes/admin/class-site-list-screen.php
+++ b/includes/admin/class-site-list-screen.php
@@ -37,7 +37,6 @@ class Site_List_Screen {
 	 * @since 2.1
 	 * @see admin_enqueue_scripts
 	 * @param string $hook Current admin page.
-	 * @return void
 	 */
 	public function load_scripts_and_styles( $hook ) {
 		global $typenow;

--- a/includes/admin/class-site-list-screen.php
+++ b/includes/admin/class-site-list-screen.php
@@ -21,22 +21,20 @@ class Site_List_Screen {
 	public function load_scripts_and_styles( $hook ) {
 		global $typenow;
 
-		if ( 'syn_site' == $typenow ) {
-			if ( in_array( $hook, array( 'post.php', 'post-new.php' ) ) ) {
+		if ( 'syn_site' === $typenow ) {
+			if ( in_array( $hook, array( 'post.php', 'post-new.php' ), true ) ) {
 				wp_enqueue_style( 'syn-edit-sites', SYNDICATION_URL . 'assets/css/admin-edit-site.css', array(), SYNDICATION_VERSION );
 			}
 		}
 	}
 
 	public function add_new_columns( $columns ) {
-
 		$new_columns                  = array();
 		$new_columns['cb']            = '<input type="checkbox" />';
-		$new_columns['title']         = _x( 'Site Name', 'column name' );
-		$new_columns['client-type']   = _x( 'Client Type', 'column name' );
-		$new_columns['syn_sitegroup'] = _x( 'Groups', 'column name' );
-		$new_columns['date']          = _x( 'Date', 'column name' );
-
+		$new_columns['title']         = _x( 'Syndication Endpoint Name', 'column name', 'push-syndication' );
+		$new_columns['client-type']   = _x( 'Client Type', 'column name', 'push-syndication' );
+		$new_columns['syn_sitegroup'] = _x( 'Groups', 'column name', 'push-syndication' );
+		$new_columns['date']          = _x( 'Date', 'column name', 'push-syndication' );
 		return $new_columns;
 	}
 

--- a/includes/class-bootstrap.php
+++ b/includes/class-bootstrap.php
@@ -15,7 +15,7 @@ class Bootstrap {
 	public function __construct() {
 
 		// Load our helper functions which autoload can't..load
-		require_once( SYNDICATION_PATH . 'includes/functions-helpers.php');
+		require_once( SYNDICATION_PATH . 'includes/functions-helpers.php' );
 
 		// Always load.
 		new Cron();
@@ -98,19 +98,18 @@ class Bootstrap {
 			'syn_sitegroup',
 			'syn_site', array(
 				'labels' => array(
-					'name'              => __( 'Site Groups' ),
-					'singular_name'     => __( 'Site Group' ),
-					'search_items'      => __( 'Search Site Groups' ),
-					'popular_items'     => __( 'Popular Site Groups' ),
-					'all_items'         => __( 'All Site Groups' ),
-					'parent_item'       => __( 'Parent Site Group' ),
-					'parent_item_colon' => __( 'Parent Site Group' ),
-					'edit_item'         => __( 'Edit Site Group' ),
-					'update_item'       => __( 'Update Site Group' ),
-					'add_new_item'      => __( 'Add New Site Group' ),
-					'new_item_name'     => __( 'New Site Group Name' ),
-					'search_items'      => __( 'Search Site Groups' ),
-					'not_found'         => __( 'No Site Groups Found' ),
+					'name'              => __( 'Syndication Endpoint Groups' ),
+					'singular_name'     => __( 'Syndication Endpoint Group' ),
+					'search_items'      => __( 'Search Syndication Endpoint Groups' ),
+					'popular_items'     => __( 'Popular Syndication Endpoint Groups' ),
+					'all_items'         => __( 'All Syndication Endpoint Groups' ),
+					'parent_item'       => __( 'Parent Syndication Endpoint Group' ),
+					'parent_item_colon' => __( 'Parent Syndication Endpoint Group' ),
+					'edit_item'         => __( 'Edit Syndication Endpoint Group' ),
+					'update_item'       => __( 'Update Syndication Endpoint Group' ),
+					'add_new_item'      => __( 'Add New Syndication Endpoint Group' ),
+					'new_item_name'     => __( 'New Syndication Endpoint Group Name' ),
+					'not_found'         => __( 'No Syndication Endpoint Groups Found' ),
 				),
 				'public'                => false,
 				'show_ui'               => true,
@@ -144,25 +143,25 @@ class Bootstrap {
 		register_post_type(
 			'syn_site', array(
 				'labels'                => array(
-					'name'                => __( 'Sites' ),
-					'singular_name'       => __( 'Site' ),
-					'add_new'             => __( 'Add Site' ),
-					'add_new_item'        => __( 'Add New Site' ),
-					'edit_item'           => __( 'Edit Site' ),
-					'new_item'            => __( 'New Site' ),
-					'view_item'           => __( 'View Site' ),
-					'search_items'        => __( 'Search Sites' ),
-					'not_found'           => __( 'No sites found' ),
-					'not_found_in_trash'  => __( 'No sites found in trash' ),
+					'name'                => __( 'Syndication Endpoints', 'push-syndication' ),
+					'singular_name'       => __( 'Syndication Endpoint', 'push-syndication' ),
+					'add_new'             => __( 'Add Syndication Endpoint', 'push-syndication' ),
+					'add_new_item'        => __( 'Add New Syndication Endpoint', 'push-syndication' ),
+					'edit_item'           => __( 'Edit Syndication Endpoint', 'push-syndication' ),
+					'new_item'            => __( 'New Syndication Endpoint', 'push-syndication' ),
+					'view_item'           => __( 'View Syndication Endpoint', 'push-syndication' ),
+					'search_items'        => __( 'Search Syndication Endpoints', 'push-syndication' ),
+					'not_found'           => __( 'No Syndication Endpoints found', 'push-syndication' ),
+					'not_found_in_trash'  => __( 'No Syndication Endpoints found in trash', 'push-syndication' ),
 				),
-				'description'           => __( 'Sites in the network' ),
+				'description'           => __( 'Syndication Endpoints in the network', 'push-syndication' ),
 				'public'                => false,
 				'show_ui'               => true,
 				'publicly_queryable'    => false,
 				'exclude_from_search'   => true,
 				'menu_position'         => 100,
 				'menu_icon'             => 'dashicons-networking',
-				'hierarchical'          => false, // @TODO check this
+				'hierarchical'          => false, // @todo check this
 				'query_var'             => false,
 				'rewrite'               => false,
 				'supports'              => array( 'title' ),

--- a/includes/class-bootstrap.php
+++ b/includes/class-bootstrap.php
@@ -1,20 +1,26 @@
 <?php
 /**
  * Plugin Bootstrap
+ *
+ * @since 2.1
+ * @package Automattic\Syndication
  */
 
 namespace Automattic\Syndication;
 
+/**
+ * Class Bootstrap
+ *
+ * @package Automattic\Syndication
+ */
 class Bootstrap {
-
 	/**
 	 * Fire up the Syndication plugin
 	 *
 	 * Note: Class Autoloading is in use
 	 */
 	public function __construct() {
-
-		// Load our helper functions which autoload can't..load
+		// Load our helper functions which autoload can't load.
 		require_once( SYNDICATION_PATH . 'includes/functions-helpers.php' );
 
 		// Always load.
@@ -62,7 +68,6 @@ class Bootstrap {
 		add_action( 'init', [ $this, 'init' ] );
 	}
 
-
 	/**
 	 * Initialize the plugin!
 	 */
@@ -83,9 +88,15 @@ class Bootstrap {
 		 * Legacy hook.
 		 */
 		do_action( 'syn_after_init_server' );
-
 	}
 
+	/**
+	 * Register Taxonomy
+	 *
+	 * Registers the Syndication Endpoint Groups taxonomy.
+	 *
+	 * @return void
+	 */
 	public function register_taxonomy() {
 		$taxonomy_capabilities = array(
 			'manage_terms' => 'manage_categories',
@@ -123,10 +134,16 @@ class Bootstrap {
 	}
 
 	/**
+	 * Register Post Type
+	 *
 	 * Set up the `syn_site` custom post type.
+	 *
+	 * @return void
 	 */
 	public function register_post_type() {
-		/* This filter is documented in includes/admin/class-settings-screen.php */
+		/*
+		 * This filter is documented in includes/admin/class-settings-screen.php
+		 */
 		$capability = apply_filters( 'syn_syndicate_cap', 'manage_options' );
 
 		$post_type_capabilities = array(
@@ -166,7 +183,6 @@ class Bootstrap {
 				'rewrite'               => false,
 				'supports'              => array( 'title' ),
 				'can_export'            => true,
-				// 'register_meta_box_cb'  => array( $this, 'site_metaboxes' ),
 				'capabilities'          => $post_type_capabilities,
 			)
 		);

--- a/includes/class-bootstrap.php
+++ b/includes/class-bootstrap.php
@@ -94,8 +94,6 @@ class Bootstrap {
 	 * Register Taxonomy
 	 *
 	 * Registers the Syndication Endpoint Groups taxonomy.
-	 *
-	 * @return void
 	 */
 	public function register_taxonomy() {
 		$taxonomy_capabilities = array(
@@ -137,8 +135,6 @@ class Bootstrap {
 	 * Register Post Type
 	 *
 	 * Set up the `syn_site` custom post type.
-	 *
-	 * @return void
 	 */
 	public function register_post_type() {
 		/*

--- a/includes/class-syndication-settings.php
+++ b/includes/class-syndication-settings.php
@@ -1,9 +1,15 @@
 <?php
+/**
+ * Handles the Syndication plugin settings
+ *
+ * @since 2.1
+ * @package Automattic\Syndication
+ */
 
 namespace Automattic\Syndication;
 
 /**
- * Syndication Settings
+ * Class Syndication_Settings
  *
  * The role of the syndication settings class is to initialize and
  * retrieve all syndication settings.
@@ -11,7 +17,6 @@ namespace Automattic\Syndication;
  * @package Automattic\Syndication
  */
 class Syndication_Settings {
-
 	protected $push_syndicate_default_settings;
 	protected $push_syndicate_settings;
 
@@ -23,10 +28,13 @@ class Syndication_Settings {
 	}
 
 	/**
+	 * Init
+	 *
 	 * Set up the syndication settings, combining defaults with stored options.
+	 *
+	 * @return void
 	 */
 	public function init() {
-
 		$this->push_syndicate_default_settings = array(
 			'selected_pull_sitegroups'  => array(),
 			'selected_post_types'       => array( 'post' ),
@@ -54,13 +62,13 @@ class Syndication_Settings {
 	 *
 	 * @return mixed             The setting value, or false if unset.
 	 */
-	public function get_setting( $setting_id, $default =false ) {
+	public function get_setting( $setting_id, $default = false ) {
 		return isset( $this->push_syndicate_settings[ $setting_id ] ) ? $this->push_syndicate_settings[ $setting_id ] : $default;
 	}
 
 	static function syndicate_encrypt( $data ) {
-
 		$data = serialize( $data );
+
 		return base64_encode(
 			mcrypt_encrypt(
 				MCRYPT_RIJNDAEL_256,
@@ -91,7 +99,6 @@ class Syndication_Settings {
 		}
 
 		return @unserialize( $data );
-
 	}
 
 	// checking user capability

--- a/includes/class-syndication-settings.php
+++ b/includes/class-syndication-settings.php
@@ -31,8 +31,6 @@ class Syndication_Settings {
 	 * Init
 	 *
 	 * Set up the syndication settings, combining defaults with stored options.
-	 *
-	 * @return void
 	 */
 	public function init() {
 		$this->push_syndicate_default_settings = array(

--- a/tests/test-bootstrap.php
+++ b/tests/test-bootstrap.php
@@ -1,0 +1,28 @@
+<?php
+namespace Automattic\Syndication;
+
+/**
+ * Tests for Class Bootstrap.
+ *
+ * @since 2.1
+ * @package Automattic\Syndication
+ */
+class Test_Bootstrap extends \WP_UnitTestCase {
+	/**
+	 * Test that post types and taxonomies are registered. More like an integration test.
+	 *
+	 * @since 2.1
+	 * @covers Bootstrap::register_post_type()
+	 * @covers Bootstrap::register_taxonomy()
+	 */
+	public function test_post_type_and_taxonomies_are_registered() {
+		$this->assertTrue( post_type_exists( 'syn_site' ) );
+		$this->assertTrue( taxonomy_exists( 'syn_sitegroup' ) );
+
+		$post_type = get_post_type_object( 'syn_site' );
+		$this->assertEquals( 'Syndication Endpoints', $post_type->labels->name );
+
+		$taxonomy = get_taxonomy( 'syn_sitegroup' );
+		$this->assertEquals( 'Syndication Endpoint Groups', $taxonomy->labels->name );
+	}
+}

--- a/tests/test-class-syndication-settings.php
+++ b/tests/test-class-syndication-settings.php
@@ -52,7 +52,7 @@ class Test_Syndication_Settings extends \WP_UnitTestCase {
 	 * @covers Syndication_Settings::get_setting()
 	 */
 	public function test_get_setting_returns_false_if_doesnt_exists() {
-		$this->assertFalse( $this->instance->get_setting( 'non_existant_setting' ) );
+		$this->assertFalse( $this->instance->get_setting( 'non_existent_setting' ) );
 	}
 
 	/**
@@ -63,7 +63,7 @@ class Test_Syndication_Settings extends \WP_UnitTestCase {
 	 * @covers Syndication_Settings::get_setting()
 	 */
 	public function test_get_setting_returns_custom_value_if_doesnt_exists() {
-		$this->assertEquals( 'empty', $this->instance->get_setting( 'non_existant_setting', 'empty' ) );
+		$this->assertEquals( 'empty', $this->instance->get_setting( 'non_existent_setting', 'empty' ) );
 	}
 
 	/**

--- a/tests/test-class-syndication-settings.php
+++ b/tests/test-class-syndication-settings.php
@@ -1,0 +1,103 @@
+<?php
+namespace Automattic\Syndication;
+
+/**
+ * Tests for Class Syndication_Settings.
+ *
+ * @since 2.1
+ * @package Automattic\Syndication
+ */
+class Test_Syndication_Settings extends \WP_UnitTestCase {
+	/**
+	 * Instance of Syndication_Settings
+	 *
+	 * @var Syndication_Settings
+	 */
+	private $instance;
+
+	/**
+	 * Setup.
+	 *
+	 * @since 2.1
+	 * @inheritdoc
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->instance = new Syndication_Settings();
+	}
+
+	/**
+	 * Test that `get_setting` returns a setting if it exists.
+	 *
+	 * @since 2.1
+	 * @covers Syndication_Settings::get_setting()
+	 */
+	public function test_get_setting_returns_a_setting_if_exists() {
+		// Add a setting.
+		add_action( 'pre_option_push_syndicate_settings', function() {
+			return array(
+				'delete_pushed_posts' => 'on',
+			);
+		} );
+
+		$this->instance->init();
+		$this->assertEquals( 'on', $this->instance->get_setting( 'delete_pushed_posts' ) );
+	}
+
+	/**
+	 * Test that `get_setting` returns a false if it doesnt exists.
+	 *
+	 * @since 2.1
+	 * @covers Syndication_Settings::get_setting()
+	 */
+	public function test_get_setting_returns_false_if_doesnt_exists() {
+		$this->assertFalse( $this->instance->get_setting( 'non_existant_setting' ) );
+	}
+
+	/**
+	 * Test that `get_setting` returns a custom value if it doesnt exists and a
+	 * custom value is pased in.
+	 *
+	 * @since 2.1
+	 * @covers Syndication_Settings::get_setting()
+	 */
+	public function test_get_setting_returns_custom_value_if_doesnt_exists() {
+		$this->assertEquals( 'empty', $this->instance->get_setting( 'non_existant_setting', 'empty' ) );
+	}
+
+	/**
+	 * Test that the default options get set on init.
+	 *
+	 * @since 2.1
+	 * @covers Syndication_Settings::init()
+	 */
+	public function test_default_options_get_set() {
+		$this->instance->init();
+		$this->assertEquals( 'off', $this->instance->get_setting( 'delete_pushed_posts' ) );
+		$this->assertEquals( 3600, $this->instance->get_setting( 'pull_time_interval' ) );
+		$this->assertEquals( '', $this->instance->get_setting( 'client_id' ) );
+	}
+
+	/**
+	 * Test that database options that are saved override the default options.
+	 *
+	 * @since 2.1
+	 * @covers Syndication_Settings::init()
+	 */
+	public function test_database_options_override_default_options() {
+		// Setup option override data.
+		add_action( 'pre_option_push_syndicate_settings', function() {
+			return array(
+				'delete_pushed_posts' => 'on',
+				'pull_time_interval'  => 7200,
+				'client_id'           => '123',
+			);
+		} );
+
+		$this->instance->init();
+		$this->assertEquals( 'on', $this->instance->get_setting( 'delete_pushed_posts' ) );
+		$this->assertEquals( 7200, $this->instance->get_setting( 'pull_time_interval' ) );
+		$this->assertEquals( '123', $this->instance->get_setting( 'client_id' ) );
+	}
+}

--- a/tests/test-upgrade-tasks.php
+++ b/tests/test-upgrade-tasks.php
@@ -15,7 +15,7 @@ class Test_Upgrade_Tasks extends \WP_UnitTestCase {
 		( new Upgrade_Tasks() )->upgrade_to_3_0_0();
 
 		$this->assertSame( $transport_type, get_post_meta( $site_id, 'syn_transport_type', true ),
-			'Upgrading to version 3.0.0 should not delete custom tranport type values.'
+			'Upgrading to version 3.0.0 should not delete custom transport type values.'
 		);
 	}
 }


### PR DESCRIPTION
* Rename Site Groups to Syndication Endpoint Groups
* Adds ui18n to labels
* Cleans up some formatting on methods touched
* Adds DocBlock to methods touched
* Removes the unneeded method `display_sitegroups_selection`
* Adds some initial unit tests